### PR TITLE
Change the behaviour of some utils

### DIFF
--- a/rewrite-indexes.js
+++ b/rewrite-indexes.js
@@ -1,4 +1,5 @@
 const { rewriteFaultyIndexes } = require('./utils/record-porcelain')
+const website = process.argv[2].toUpperCase()
 
 function run() {
   rewriteFaultyIndexes()

--- a/rewrite-indexes.js
+++ b/rewrite-indexes.js
@@ -2,7 +2,7 @@ const { rewriteFaultyIndexes } = require('./utils/record-porcelain')
 const website = process.argv[2].toUpperCase()
 
 function run() {
-  rewriteFaultyIndexes()
+  rewriteFaultyIndexes(website)
   return
 }
 

--- a/scrap-new-link.js
+++ b/scrap-new-link.js
@@ -22,7 +22,7 @@ async function run() {
   for await (const line of readInterface) {
     console.log('Grabbing prices for ', line)
 
-    if (entryExists(line)) {
+    if (entryExists(website, line)) {
       console.log('Link already exists..')
       continue
     }

--- a/scrap-new-set.js
+++ b/scrap-new-set.js
@@ -32,7 +32,7 @@ async function run() {
       console.log('New Scrapped Set:', scrappedSet.scrapped_entries)
 
       // console.log('Set appending prevented..')
-      appendNewSet(entryStart, scrappedSet)
+      appendNewSet(website, entryStart, scrappedSet)
       break
     }
 
@@ -70,7 +70,7 @@ async function run() {
     }
 
     // console.log('Set appending prevented..')
-    appendNewSet(i, scrappedSet)
+    appendNewSet(website, i, scrappedSet)
     entriesUpdated++
   }
 

--- a/utils/entry-management.js
+++ b/utils/entry-management.js
@@ -35,7 +35,7 @@ function saveEntryToFile(website, entry, appendToOldEntries) {
   }
 }
 
-function entryExists(entry) {
+function entryExists(website, entry) {
   let entries
 
   const jsonFilePath = path.join(
@@ -57,7 +57,7 @@ function entryExists(entry) {
   return false
 }
 
-function appendNewSet(entryIndex, newEntry) {
+function appendNewSet(website, entryIndex, newEntry) {
   let entries, entryToBeUpdated, newScrappedSet
 
   const jsonFilePath = path.join(
@@ -87,7 +87,7 @@ function appendNewSet(entryIndex, newEntry) {
   return true
 }
 
-function saveNewEntry(entry) {
+function saveNewEntry(website, entry) {
   let entries, index, newEntry
 
   const jsonFilePath = path.join(

--- a/utils/entry-management.js
+++ b/utils/entry-management.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const path = require('path')
 const { env } = require('process')
 
-const website = process.argv[2].toUpperCase()
 // const filePath = path.join(__dirname, 'txt', `${website}_links.txt`)
 // const txtFilePath = path.join(__dirname, '../', 'txt', `${website}_links.txt`)
 function saveEntryToFile(website, entry, appendToOldEntries) {

--- a/utils/entry-management.js
+++ b/utils/entry-management.js
@@ -38,6 +38,12 @@ function saveEntryToFile(website, entry, appendToOldEntries) {
 function entryExists(entry) {
   let entries
 
+  const jsonFilePath = path.join(
+    __dirname,
+    '..',
+    'collections',
+    `${website.toUpperCase()}.json`
+  )
   const data = fs.readFileSync(jsonFilePath, { encoding: 'utf8' })
   entries = JSON.parse(data)
 
@@ -53,6 +59,13 @@ function entryExists(entry) {
 
 function appendNewSet(entryIndex, newEntry) {
   let entries, entryToBeUpdated, newScrappedSet
+
+  const jsonFilePath = path.join(
+    __dirname,
+    '..',
+    'collections',
+    `${website.toUpperCase()}.json`
+  )
   const data = fs.readFileSync(jsonFilePath, { encoding: 'utf8' })
   entries = JSON.parse(data)
 
@@ -76,6 +89,13 @@ function appendNewSet(entryIndex, newEntry) {
 
 function saveNewEntry(entry) {
   let entries, index, newEntry
+
+  const jsonFilePath = path.join(
+    __dirname,
+    '..',
+    'collections',
+    `${website.toUpperCase()}.json`
+  )
   const data = fs.readFileSync(jsonFilePath, { encoding: 'utf8' })
   entries = JSON.parse(data)
 

--- a/utils/entry-management.js
+++ b/utils/entry-management.js
@@ -4,14 +4,7 @@ const { env } = require('process')
 
 const website = process.argv[2].toUpperCase()
 // const filePath = path.join(__dirname, 'txt', `${website}_links.txt`)
-const jsonFilePath = path.join(
-  __dirname,
-  '..',
-  'collections',
-  `${website}.json`
-)
 // const txtFilePath = path.join(__dirname, '../', 'txt', `${website}_links.txt`)
-
 function saveEntryToFile(website, entry, appendToOldEntries) {
   if (website == '' || !website || typeof website !== 'string') {
     throw new Error('Argument must be a valid String')

--- a/utils/entry-management.js
+++ b/utils/entry-management.js
@@ -21,16 +21,16 @@ function saveEntryToFile(website, entry, appendToOldEntries) {
     createJsonCollectionFile(website)
     return true
   } else {
-    entryIndex = entryExists(entry)
+    entryIndex = entryExists(website, entry)
   }
 
   if (!entryIndex) {
-    saveNewEntry(entry)
+    saveNewEntry(website, entry)
     return true
   }
 
   if (entryIndex && appendToOldEntries) {
-    appendNewSet(entryIndex, entry)
+    appendNewSet(website, entryIndex, entry)
     return true
   }
 }

--- a/utils/record-porcelain.js
+++ b/utils/record-porcelain.js
@@ -7,7 +7,7 @@ const jsonFilePath = path.join(
   `${website}.json`
 )
 
-function rewriteFaultyIndexes() {
+function rewriteFaultyIndexes(website) {
   let numChanges = 0
   const data = fs.readFileSync(jsonFilePath, { encoding: 'utf8' })
   const entries = JSON.parse(data).links

--- a/utils/record-porcelain.js
+++ b/utils/record-porcelain.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const path = require('path')
-const website = process.argv[2].toUpperCase()
 const jsonFilePath = path.join(
   __dirname,
   '..',

--- a/utils/record-porcelain.js
+++ b/utils/record-porcelain.js
@@ -3,14 +3,14 @@ const path = require('path')
 
 function rewriteFaultyIndexes(website) {
   let numChanges = 0
+  const jsonFilePath = path.join(
+    __dirname,
+    '..',
+    'collections',
+    `${website}.json`
+  )
   const data = fs.readFileSync(jsonFilePath, { encoding: 'utf8' })
   const entries = JSON.parse(data).links
-  const jsonFilePath = path.join(
-  __dirname,
-  '..',
-  'collections',
-  `${website}.json`
-)
 
   for (let i = 0; i < entries.length - 1; i++) {
     const currentRecord = entries[i]

--- a/utils/record-porcelain.js
+++ b/utils/record-porcelain.js
@@ -1,16 +1,16 @@
 const fs = require('fs')
 const path = require('path')
-const jsonFilePath = path.join(
-  __dirname,
-  '..',
-  'collections',
-  `${website}.json`
-)
 
 function rewriteFaultyIndexes(website) {
   let numChanges = 0
   const data = fs.readFileSync(jsonFilePath, { encoding: 'utf8' })
   const entries = JSON.parse(data).links
+  const jsonFilePath = path.join(
+  __dirname,
+  '..',
+  'collections',
+  `${website}.json`
+)
 
   for (let i = 0; i < entries.length - 1; i++) {
     const currentRecord = entries[i]


### PR DESCRIPTION
This PR changes the behavior of some files under `/utils` so they rely on its function arguments rather than on the `process.argv` array. The following files have been changed:
- `/utils/record-porcelain.js` 
    -  Changed function definitions. Now they expect a `website` as its first argument
    - Update functions calls. Now `website` parameter is first entered
    - Move `jsonFilePath` constant to inside function `rewriteFaultyIndexes()`
- `/utils/entry-management.js` 
    - Remove `website` constant
    - Changed functions definitions. Now they expect a `website` as its first argument
    - Update functions calls. Now `website` parameter is first entered
    - Move `jsonFilePath` constant to inside of some function definitions
- `rewrite-indexes.js` -- 
    - Create `website` constant
    - Update function call. Now `website` parameter is entered first
- `scrap-new-link.js` 
    - Update function call
 - `scrap-new-set.js` 
    - Update functions calls
