### PR TITLE
Fix records always being rewritten

### DIFF
--- a/utils/record-porcelain.js
+++ b/utils/record-porcelain.js
@@ -16,7 +16,7 @@ function rewriteFaultyIndexes(website) {
     const currentRecord = entries[i]
     const nextRecord = entries[i + 1]
 
-    if (nextRecord.index !== currentRecord + 1) {
+    if (nextRecord.index !== currentRecord.index + 1) {
       nextRecord.index = currentRecord.index + 1
       numChanges++
     }


### PR DESCRIPTION
The function `rewriteFaultyIndexes()` used to always rewritte every single index in a given collection file regardless of whether it actually contained gaps between indexes. This behavior was produced by a faulty comparison statement that used to yield true. This PR fixes this statement and now the function works as intended.