### PR TITLE
Incorrect formatting of days to months 

### DIFF
--- a/__test__/set-transform.test.js
+++ b/__test__/set-transform.test.js
@@ -115,6 +115,51 @@ describe('Set transformation utilities', () => {
     expect(set).toEqual(normalizedSet)
   })
 
+  it('normalizes the scrapped set into the standarized form (multiple months as days case)', () => {
+    const initialSet = [
+      {
+        duration: '12',
+        type: 'Month',
+        price: '119.99',
+        includesDownloads: true
+      },
+      {
+        duration: '2',
+        type: 'Day',
+        price: '1.00',
+        includesDownloads: false
+      },
+      {
+        duration: '90',
+        type: 'Day',
+        price: '39.99',
+        includesDownloads: false
+      }
+    ]
+    const set = normalizeSet(initialSet)
+    const normalizedSet = [
+      {
+        duration: '1',
+        type: 'Year',
+        price: '119.99',
+        includesDownloads: true
+      },
+      {
+        duration: '2',
+        type: 'Day',
+        price: '1.00',
+        includesDownloads: false
+      },
+      {
+        duration: '3',
+        type: 'Month',
+        price: '39.99',
+        includesDownloads: false
+      }
+    ]
+    expect(set).toEqual(normalizedSet)
+  })
+
   it('normalizes the scrapped set into the standarized form (more than 12 months case)', () => {
     const initialSet = [
       {

--- a/utils/set-transform.js
+++ b/utils/set-transform.js
@@ -84,6 +84,11 @@ function normalizeSet(setArray) {
         if (Number.parseInt(currentSet.duration) == 30) {
           type = 'Month'
           duration = '1'
+        } else if (
+          Number.isInteger(Number.parseInt(currentSet.duration) / 30)
+        ) {
+          type = 'Month'
+          duration = `${Number.parseInt(currentSet.duration) / 30}`
         }
 
         transformedScrap = {


### PR DESCRIPTION
This PR fixes the troublesome scenario where when encountering multiple months being represented as days (i.e. 60, 90, etc.) the would fail to parse it the monthly equivalent, thus resulting in records stating the interval of `"DAYS"` but having a value higher than 30.

A new test has been added to `/__test_/set-transform.test.js` that tackles the scenario previously talked about.