### PR TITLE
Lifetime intervals fix

### DIFF
--- a/__test__/text-parsing.test.js
+++ b/__test__/text-parsing.test.js
@@ -9,8 +9,10 @@ describe('Correct parsing of text data (normal)', () => {
   const oneYearText = '1 Year Membership'
   const downloadText = `12 Month Membership + Downloads, 30 Day Membership + Downloads include Downloads. Access to Downloads expires when Brazzers expires.`
   const priceText = '$27.99 /Month'
-  const trialText = '****Limited access 2 day trial period automatically rebills at $39.99 every 30 days until cancelled'
-  const weekText = '**7 Day Membership initial charge of $7.00 automatically rebilling at $39.99 every 30 day until cancelled.'
+  const trialText =
+    '****Limited access 2 day trial period automatically rebills at $39.99 every 30 days until cancelled'
+  const weekText =
+    '**7 Day Membership initial charge of $7.00 automatically rebilling at $39.99 every 30 day until cancelled.'
 
   it('Parses a monthly interval correctly', () => {
     let interval = getInterval(oneMonthText)
@@ -39,7 +41,7 @@ describe('Correct parsing of text data (normal)', () => {
 
   it('Parses a membership that includes downloads correctly', () => {
     let includesDownloads = checkForDownloads(downloadText)
-    let expectedArray = [{1:'Year'}, {1:'Month'}]
+    let expectedArray = [{ 1: 'Year' }, { 1: 'Month' }]
     expect(includesDownloads).toEqual(expectedArray)
   })
 
@@ -67,5 +69,20 @@ describe('Correct parsing of text data (alternative)', () => {
   it('Parses the price of a membership correclty', () => {
     let price = getPrice(priceText)
     expect(price).toBe('27.99')
+  })
+})
+
+describe('Correct parsing of text data when unusual intervals are encountered', () => {
+  const lifetimeText =
+    '***Lifetime Membership (25 Years) initial charge of $199.99 non-recurring.'
+
+  it('Parses a lifetime interval data correctly', () => {
+    let interval = getInterval(lifetimeText)
+    let price = getPrice(lifetimeText)
+    let hasDownloads = checkForDownloads(lifetimeText)
+
+    expect(interval).toEqual({ type: 'Lifetime', value: '1' })
+    expect(price).toEqual('199.99')
+    expect(hasDownloads).toEqual(false)
   })
 })

--- a/utils/set-transform.js
+++ b/utils/set-transform.js
@@ -158,6 +158,15 @@ function normalizeSet(setArray) {
         }
         break
 
+      case 'LIFETIME':
+        transformedScrap = {
+          duration: currentSet.duration,
+          type: currentSet.type,
+          price: price || currentSet.price,
+          includesDownloads
+        }
+        break
+
       default:
         transformedScrap = {
           duration: false,

--- a/utils/set-transform.js
+++ b/utils/set-transform.js
@@ -2,6 +2,7 @@ const { getPrice, getInterval, checkForDownloads } = require('./text-parsing')
 
 function createSet(textsArray) {
   const main_text_regex = /^\*+\d{1,2}.*$/
+  const lifetime_text_regex = /^\*+(:?lifetime).*$/i
   const trial_text_regex = /^\*{1,4}.+(:?2 day)/i
   const week_trial_interval_regex = /^\*+full access.*$/i
 
@@ -21,6 +22,7 @@ function createSet(textsArray) {
     if (
       main_text_regex.test(currentText) ||
       trial_text_regex.test(currentText) ||
+      lifetime_text_regex.test(currentText) ||
       week_trial_interval_regex.test(currentText) ||
       checkForDownloads(currentText)
     )

--- a/utils/text-parsing.js
+++ b/utils/text-parsing.js
@@ -8,11 +8,10 @@ function getInterval(text) {
     intervalType = interval_type_regex.exec(text)[1]
   }
 
-  if (interval_value_regex.test(text)) {
+  if (intervalType === 'Lifetime') {
+    intervalValue = '1'
+  } else if (interval_value_regex.test(text)) {
     intervalValue = interval_value_regex.exec(text)[1]
-  } else if (/lifetime/i.test(intervalType)) {
-    intervalValue = 1
-    intervalType = 'Litetime'
   } else if (trial_interval_regex.test(text)) {
     intervalValue = 2
     intervalType = 'Day'


### PR DESCRIPTION
This PR fixes the appending of _Lifetime_ intervals into a scraped set. Now, every time the app encounters a set that includes such interval, this one gets appended to the final scraped set.

## Important Changes
- New regex created for the _Lifetime_ interval
- New case addded to swtich statement responsible for normalizing the scraped set
- New test suite added 