### PR TITLE
Add set sorting

### DIFF
--- a/__test__/set-transform.test.js
+++ b/__test__/set-transform.test.js
@@ -1,5 +1,7 @@
 const {
+  sortSets,
   createSet,
+  segmentSet,
   normalizeSet,
   appendDownloads
 } = require('../utils/set-transform')
@@ -399,5 +401,334 @@ describe('Set transformation utilities', () => {
     const intervalsWithDownloads = [{ 1: 'Year' }, { 1: 'Month' }]
     appendDownloads(initialSet, intervalsWithDownloads)
     expect(initialSet).toEqual(transformedSet)
+  })
+
+  it('Segments intervals correctly (normal case)', () => {
+    let segmentedSets
+
+    const initialSet = [
+      {
+        duration: '1',
+        type: 'Year',
+        price: '121.99',
+        includesDownloads: true
+      },
+      {
+        duration: '1',
+        type: 'Month',
+        price: '17.99',
+        includesDownloads: false
+      },
+      {
+        duration: '1',
+        type: 'Month',
+        price: '24.99',
+        includesDownloads: true
+      },
+      {
+        duration: '2',
+        type: 'Day',
+        price: '7.99',
+        includesDownloads: false
+      }
+    ]
+
+    const expectedSegments = [
+      [
+        {
+          duration: '2',
+          type: 'Day',
+          price: '7.99',
+          includesDownloads: false
+        }
+      ],
+      [
+        {
+          duration: '1',
+          type: 'Month',
+          price: '17.99',
+          includesDownloads: false
+        },
+        {
+          duration: '1',
+          type: 'Month',
+          price: '24.99',
+          includesDownloads: true
+        }
+      ],
+      [
+        {
+          duration: '1',
+          type: 'Year',
+          price: '121.99',
+          includesDownloads: true
+        }
+      ]
+    ]
+
+    segmentedSets = segmentSet(initialSet)
+    expect(segmentedSets).toStrictEqual(expectedSegments)
+  })
+
+  it('Segments intervals correctly (multiple month intervals)', () => {
+    let segmentedSets
+
+    const initialSet = [
+      {
+        duration: '18',
+        type: 'Month',
+        price: '141.99',
+        includesDownloads: true
+      },
+      {
+        duration: '3',
+        type: 'Month',
+        price: '53.99',
+        includesDownloads: false
+      },
+      {
+        duration: '1',
+        type: 'Month',
+        price: '24.99',
+        includesDownloads: true
+      },
+      {
+        duration: '2',
+        type: 'Day',
+        price: '7.99',
+        includesDownloads: false
+      }
+    ]
+
+    const expectedSegments = [
+      [
+        {
+          duration: '2',
+          type: 'Day',
+          price: '7.99',
+          includesDownloads: false
+        }
+      ],
+      [
+        {
+          duration: '18',
+          type: 'Month',
+          price: '141.99',
+          includesDownloads: true
+        },
+        {
+          duration: '3',
+          type: 'Month',
+          price: '53.99',
+          includesDownloads: false
+        },
+        {
+          duration: '1',
+          type: 'Month',
+          price: '24.99',
+          includesDownloads: true
+        }
+      ]
+    ]
+
+    segmentedSets = segmentSet(initialSet)
+    expect(segmentedSets).toStrictEqual(expectedSegments)
+  })
+
+  it('Segments intervals correctly (lifetime case)', () => {
+    let segmentedSets
+
+    const initialSet = [
+      {
+        duration: '1',
+        type: 'Year',
+        price: '119.99',
+        includesDownloads: false
+      },
+      {
+        duration: '1',
+        type: 'Lifetime',
+        price: '199.99',
+        includesDownloads: false
+      },
+      {
+        duration: '1',
+        type: 'Month',
+        price: '14.99',
+        includesDownloads: true
+      },
+      {
+        duration: '2',
+        type: 'Day',
+        price: '7.99',
+        includesDownloads: false
+      }
+    ]
+
+    const expectedSegments = [
+      [
+        {
+          duration: '2',
+          type: 'Day',
+          price: '7.99',
+          includesDownloads: false
+        }
+      ],
+      [
+        {
+          duration: '1',
+          type: 'Month',
+          price: '14.99',
+          includesDownloads: true
+        }
+      ],
+      [
+        {
+          duration: '1',
+          type: 'Year',
+          price: '119.99',
+          includesDownloads: false
+        }
+      ],
+      [
+        {
+          duration: '1',
+          type: 'Lifetime',
+          price: '199.99',
+          includesDownloads: false
+        }
+      ]
+    ]
+
+    segmentedSets = segmentSet(initialSet)
+    expect(segmentedSets).toStrictEqual(expectedSegments)
+  })
+
+  it('Sorts the segmented sets correctly', () => {
+    let sortedSet
+
+    const segmentedSets = [
+      [
+        {
+          duration: '2',
+          type: 'Day',
+          price: '1.99',
+          includesDownloads: false
+        },
+        {
+          duration: '7',
+          type: 'Day',
+          price: '7.00',
+          includesDownloads: false
+        }
+      ],
+      [
+        {
+          duration: '3',
+          type: 'Month',
+          price: '53.99',
+          includesDownloads: false
+        },
+        {
+          duration: '1',
+          type: 'Month',
+          price: '14.99',
+          includesDownloads: true
+        }
+      ]
+    ]
+
+    const expectedSet = [
+      {
+        duration: '2',
+        type: 'Day',
+        price: '1.99',
+        includesDownloads: false
+      },
+      {
+        duration: '7',
+        type: 'Day',
+        price: '7.00',
+        includesDownloads: false
+      },
+      {
+        duration: '1',
+        type: 'Month',
+        price: '14.99',
+        includesDownloads: true
+      },
+      {
+        duration: '3',
+        type: 'Month',
+        price: '53.99',
+        includesDownloads: false
+      }
+    ]
+
+    sortedSet = sortSets(segmentedSets)
+    expect(sortedSet).toStrictEqual(expectedSet)
+  })
+
+  it('Segments & sorts a given set', () => {
+    let segmentedSets, sortedSet
+
+    const initialSet = [
+        {
+          duration: '1',
+          type: 'Year',
+          price: '119.99',
+          includesDownloads: true
+        },
+        {
+          duration: '1',
+          type: 'Month',
+          price: '14.99',
+          includesDownloads: false
+        },
+        {
+          duration: '7',
+          type: 'Day',
+          price: '7.00',
+          includesDownloads: false
+        },
+        {
+          duration: '2',
+          type: 'Day',
+          price: '1.99',
+          includesDownloads: false
+        }
+    ]
+
+    const expectedSet = [
+      {
+        duration: '2',
+        type: 'Day',
+        price: '1.99',
+        includesDownloads: false
+      },
+      {
+        duration: '7',
+        type: 'Day',
+        price: '7.00',
+        includesDownloads: false
+      },
+      {
+        duration: '1',
+        type: 'Month',
+        price: '14.99',
+        includesDownloads: false
+      },
+      {
+        duration: '1',
+        type: 'Year',
+        price: '119.99',
+        includesDownloads: true
+      }
+    ]
+
+    segmentedSets = segmentSet(initialSet)
+    sortedSet = sortSets(segmentedSets)
+
+    expect(sortedSet).toStrictEqual(expectedSet)
   })
 })

--- a/scrape-new-link.js
+++ b/scrape-new-link.js
@@ -31,6 +31,9 @@ async function run() {
     }
 
     const data = await scrapePrices(line)
+    sortedSet = segmentSet(data.scraped_entries)
+    sortedSet = sortSets(sortedSet)
+    data.scraped_entries = sortedSet
 
     console.log('final scraped prices', data.scraped_entries, '\n')
 

--- a/scrape-new-link.js
+++ b/scrape-new-link.js
@@ -5,6 +5,7 @@ const path = require('path')
 const { scrapePrices } = require('./utils/price-scraper')
 const { saveEntryToFile, entryExists } = require('./utils/entry-management')
 const { incrementWebsiteLinksNumber } = require('./utils/website-management')
+const { segmentSet, sortSets } = require('./utils/set-transform')
 const website = process.argv[2].toUpperCase()
 const filePath = path.join(__dirname, 'txt', `${website}_links.txt`)
 

--- a/scrape-new-set.js
+++ b/scrape-new-set.js
@@ -31,6 +31,9 @@ async function run() {
       if (entry.index !== entryStart) continue
       console.log('Scraping Link: ', entry.link)
       scrapedSet = await scrapePrices(entry.link)
+      sortedSet = segmentSet(scrapedSet.scraped_entries)
+      sortedSet = sortSets(sortedSet)
+      scrapedSet.scraped_entries = sortedSet
       console.log('New Scraped Set:', scrapedSet.scraped_entries)
 
       if (process.env.MODE === 'APPEND') {
@@ -68,6 +71,9 @@ async function run() {
     console.log(`Link: ${currentEntry.link}`)
 
     scrapedSet = await scrapePrices(currentEntry.link)
+    sortedSet = segmentSet(scrapedSet.scraped_entries)
+    sortedSet = sortSets(sortedSet)
+    scrapedSet.scraped_entries = sortedSet
     console.log('New Scraped Set:', scrapedSet.scraped_entries)
 
     if (!scrapedSet.scraped_entries.length) {

--- a/scrape-new-set.js
+++ b/scrape-new-set.js
@@ -3,6 +3,7 @@ const path = require('path')
 const { scrapePrices } = require('./utils/price-scraper')
 const { appendNewSet } = require('./utils/entry-management')
 const { readFileSync } = require('fs')
+const { segmentSet, sortSets } = require('./utils/set-transform')
 const website = process.argv[2].toUpperCase()
 const entryStart = Number.parseInt(process.argv[3])
 const entryEnd = process.argv[4] ? Number.parseInt(process.argv[4]) : null

--- a/utils/set-transform.js
+++ b/utils/set-transform.js
@@ -215,4 +215,41 @@ function appendDownloads(set, intervalsWithDownloads) {
   }
 }
 
+function segmentSet(intervalSet) {
+  let intervalCollection
+
+  const daysIntervals = []
+  const monthsIntervals = []
+  const yearsIntervals = []
+  const lifetimeIntervals = []
+
+  for (let interval of intervalSet) {
+    const type = interval.type
+    switch (type) {
+      case 'Day':
+        daysIntervals.push(interval)
+        break
+
+      case 'Month':
+        monthsIntervals.push(interval)
+        break
+
+      case 'Year':
+        yearsIntervals.push(interval)
+        break
+
+      case 'Lifetime':
+        lifetimeIntervals.push(interval)
+        break
+
+      default:
+        break
+    }
+  }
+
+  intervalCollection = [daysIntervals, monthsIntervals, yearsIntervals, lifetimeIntervals]
+
+  return intervalCollection.filter(set => set.length)
+}
+
 module.exports = { createSet, normalizeSet, appendDownloads }

--- a/utils/set-transform.js
+++ b/utils/set-transform.js
@@ -252,4 +252,30 @@ function segmentSet(intervalSet) {
   return intervalCollection.filter(set => set.length)
 }
 
+function sortSets(sets) {
+  const sortedSets = []
+
+  if (!sets.length)
+    throw new Error('Segments Arrays are empty')
+
+  for(const set of sets) {
+    const sortedSet = set.sort((a, b) => {
+      if (a.duration > b.duration)
+        return 1
+      else if (a.duration < b.duration)
+        return -1
+      else if (a.duration === b.duration) {
+        if (a.price > b.price)
+          return 1
+        else
+          return -1
+      }
+    })
+
+    sortedSets.push(sortedSet)
+  }
+
+  return sortedSets.flat()
+}
+
 module.exports = { createSet, normalizeSet, appendDownloads }

--- a/utils/set-transform.js
+++ b/utils/set-transform.js
@@ -247,28 +247,28 @@ function segmentSet(intervalSet) {
     }
   }
 
-  intervalCollection = [daysIntervals, monthsIntervals, yearsIntervals, lifetimeIntervals]
+  intervalCollection = [
+    daysIntervals,
+    monthsIntervals,
+    yearsIntervals,
+    lifetimeIntervals
+  ]
 
-  return intervalCollection.filter(set => set.length)
+  return intervalCollection.filter((set) => set.length)
 }
 
 function sortSets(sets) {
   const sortedSets = []
 
-  if (!sets.length)
-    throw new Error('Segments Arrays are empty')
+  if (!sets.length) throw new Error('Segments Arrays are empty')
 
-  for(const set of sets) {
+  for (const set of sets) {
     const sortedSet = set.sort((a, b) => {
-      if (a.duration > b.duration)
-        return 1
-      else if (a.duration < b.duration)
-        return -1
+      if (a.duration > b.duration) return 1
+      else if (a.duration < b.duration) return -1
       else if (a.duration === b.duration) {
-        if (a.price > b.price)
-          return 1
-        else
-          return -1
+        if (a.price > b.price) return 1
+        else return -1
       }
     })
 
@@ -278,4 +278,10 @@ function sortSets(sets) {
   return sortedSets.flat()
 }
 
-module.exports = { createSet, normalizeSet, appendDownloads }
+module.exports = {
+  createSet,
+  sortSets,
+  segmentSet,
+  normalizeSet,
+  appendDownloads
+}


### PR DESCRIPTION
This PR adds the sorting functionality to the scraped interval sets. Now, every time a scraped interval set is retrieved, the set is sorted in the next order:

_days→months→years→others_

